### PR TITLE
fix: 修复git-cliff无法识别中文冒号的提交消息格式

### DIFF
--- a/cliff.toml
+++ b/cliff.toml
@@ -20,22 +20,22 @@ split_commits = false
 
 # regex for parsing and grouping commits
 commit_parsers = [
-    { message = "^feat", group = "新增 | Feat" },
-    { message = "^fix", group = "修复 | Fix" },
-    { message = "^docs", group = "文档 | Docs" },
-    { message = "^perf", group = "优化 | Perf" },
+    { message = "^feat[：:]", group = "新增 | Feat" },
+    { message = "^fix[：:]", group = "修复 | Fix" },
+    { message = "^docs[：:]", group = "文档 | Docs" },
+    { message = "^perf[：:]", group = "优化 | Perf" },
     { message = "^refactor\\(clippy\\)", skip = true },
-    { message = "^refactor", group = "重构 | Refactor" },
-    { message = "^style", group = "样式 | Style" },
-    { message = "^test", group = "测试 | Test" },
+    { message = "^refactor[：:]", group = "重构 | Refactor" },
+    { message = "^style[：:]", group = "样式 | Style" },
+    { message = "^test[：:]", group = "测试 | Test" },
     { message = "^chore\\(release\\): prepare for", skip = true },
     { message = "^chore\\(deps.*\\)", skip = true },
     { message = "^chore\\(pr\\)", skip = true },
     { message = "^chore\\(pull\\)", skip = true },
     { message = "^chore\\(npm\\).*yarn\\.lock", skip = true },
-    { message = "^chore", group = "杂项 | Chore" },
-    { message = "^other", group = "其它 | Other" },
-    { message = "^ci", group = "集成 | CI" },
+    { message = "^chore[：:]", group = "杂项 | Chore" },
+    { message = "^other[：:]", group = "其它 | Other" },
+    { message = "^ci[：:]", group = "集成 | CI" },
 ]
 # protect breaking changes from being skipped due to matching a skipping commit_parser
 protect_breaking_commits = false


### PR DESCRIPTION
目前用中文冒号的commit都无法正常被填入release body，只剩mirror酱了：
<img width="1118" height="646" alt="image" src="https://github.com/user-attachments/assets/cccf6e95-3d6e-452c-93c5-144a1d65e792" />

用英文冒号的commit可以
<img width="1111" height="748" alt="image" src="https://github.com/user-attachments/assets/d434891c-262e-4626-bcc9-ddc94d4c36bf" />


本PR修复了这个问题