### PR TITLE
feat: 开服检测改为 focus + command 通知链路（移除 Notice 依赖）

### DIFF
--- a/assets/interface.json
+++ b/assets/interface.json
@@ -97,22 +97,20 @@
             ]
         }
     ],
+    "global_option": [
+        "通知渠道设置"
+    ],
     "task": [
         {
-            "name": "启动",
+            "name": "开服检测",
             "default_check": true,
             "entry": "启动",
+            "option": [
+                "通知渠道设置"
+            ],
             "pipeline_override": {
-                "二次检测主界面": {
-                    "action": {
-                        "type": "Custom",
-                        "param": {
-                            "custom_action": "Notice",
-                            "custom_action_param": {
-                                "action": "set_Currency"
-                            }
-                        }
-                    }
+                "检查分辨率": {
+                    "enabled": false
                 }
             }
         },
@@ -445,6 +443,142 @@
         }
     ],
     "option": {
+        "通知渠道设置": {
+            "label": "通知渠道设置",
+            "description": "<p>用于开服检测通知节点：MAA 消息通道 + 主控机 PowerShell 弹窗/闹钟/邮件（Command）。</p><p>收件邮箱可填多个，用英文逗号分隔。</p>",
+            "type": "input",
+            "inputs": [
+                {
+                    "name": "SMTP服务器",
+                    "default": "smtp.qq.com",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "SMTP端口",
+                    "default": "465",
+                    "pipeline_type": "int"
+                },
+                {
+                    "name": "发件邮箱",
+                    "default": "",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "SMTP授权码",
+                    "default": "",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "收件邮箱",
+                    "description": "<p>多个邮箱请用英文逗号分隔。</p>",
+                    "default": "",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "邮件主题",
+                    "default": "MAA_SnowBreak 告警",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "弹窗标题",
+                    "default": "MAA_SnowBreak 告警",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "通知内容",
+                    "default": "检测到启动异常或通知流程失败，请尽快检查游戏状态。",
+                    "pipeline_type": "string"
+                },
+                {
+                    "name": "启用邮件通知",
+                    "default": "false",
+                    "pipeline_type": "bool"
+                }
+            ],
+            "pipeline_override": {
+                "通知": {
+                    "focus": {
+                        "Node.Action.Succeeded": {
+                            "content": "{通知内容}",
+                            "display": [
+                                "log",
+                                "toast",
+                                "notification",
+                                "dialog"
+                            ]
+                        }
+                    },
+                    "action": {
+                        "type": "Command",
+                        "param": {
+                            "exec": "powershell",
+                            "args": [
+                                "-NoProfile",
+                                "-ExecutionPolicy",
+                                "Bypass",
+                                "-Command",
+                                "$ErrorActionPreference='SilentlyContinue'; $msg='{通知内容}'; $title='{弹窗标题}'; try { [console]::Beep(1200,300); Start-Sleep -Milliseconds 120; [console]::Beep(1200,300) } catch {}; Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($msg,$title)|Out-Null; if ('{启用邮件通知}' -eq 'true' -and '{SMTP服务器}' -ne '' -and '{发件邮箱}' -ne '' -and '{SMTP授权码}' -ne '' -and '{收件邮箱}' -ne '') { $to='{收件邮箱}'.Replace(';',',').Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }; Send-MailMessage -SmtpServer '{SMTP服务器}' -Port {SMTP端口} -UseSsl -Credential (New-Object System.Management.Automation.PSCredential('{发件邮箱}', (ConvertTo-SecureString '{SMTP授权码}' -AsPlainText -Force))) -From '{发件邮箱}' -To $to -Subject '{邮件主题}' -Body $msg -Encoding UTF8 }"
+                            ],
+                            "detach": true
+                        }
+                    }
+                },
+                "其他通知": {
+                    "focus": {
+                        "Node.Action.Succeeded": {
+                            "content": "{通知内容}",
+                            "display": [
+                                "log",
+                                "toast",
+                                "notification",
+                                "dialog"
+                            ]
+                        }
+                    },
+                    "action": {
+                        "type": "Command",
+                        "param": {
+                            "exec": "powershell",
+                            "args": [
+                                "-NoProfile",
+                                "-ExecutionPolicy",
+                                "Bypass",
+                                "-Command",
+                                "$ErrorActionPreference='SilentlyContinue'; $msg='{通知内容}'; $title='{弹窗标题}'; try { [console]::Beep(1200,300); Start-Sleep -Milliseconds 120; [console]::Beep(1200,300) } catch {}; Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($msg,$title)|Out-Null; if ('{启用邮件通知}' -eq 'true' -and '{SMTP服务器}' -ne '' -and '{发件邮箱}' -ne '' -and '{SMTP授权码}' -ne '' -and '{收件邮箱}' -ne '') { $to='{收件邮箱}'.Replace(';',',').Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }; Send-MailMessage -SmtpServer '{SMTP服务器}' -Port {SMTP端口} -UseSsl -Credential (New-Object System.Management.Automation.PSCredential('{发件邮箱}', (ConvertTo-SecureString '{SMTP授权码}' -AsPlainText -Force))) -From '{发件邮箱}' -To $to -Subject '{邮件主题}' -Body $msg -Encoding UTF8 }"
+                            ],
+                            "detach": true
+                        }
+                    }
+                },
+                "通知失败": {
+                    "focus": {
+                        "Node.Action.Succeeded": {
+                            "content": "{通知内容}",
+                            "display": [
+                                "log",
+                                "toast",
+                                "notification",
+                                "modal"
+                            ]
+                        }
+                    },
+                    "action": {
+                        "type": "Command",
+                        "param": {
+                            "exec": "powershell",
+                            "args": [
+                                "-NoProfile",
+                                "-ExecutionPolicy",
+                                "Bypass",
+                                "-Command",
+                                "$ErrorActionPreference='SilentlyContinue'; $msg='{通知内容}'; $title='{弹窗标题}'; try { [console]::Beep(1200,300); Start-Sleep -Milliseconds 120; [console]::Beep(1200,300) } catch {}; Add-Type -AssemblyName PresentationFramework; [System.Windows.MessageBox]::Show($msg,$title)|Out-Null; if ('{启用邮件通知}' -eq 'true' -and '{SMTP服务器}' -ne '' -and '{发件邮箱}' -ne '' -and '{SMTP授权码}' -ne '' -and '{收件邮箱}' -ne '') { $to='{收件邮箱}'.Replace(';',',').Split(',') | ForEach-Object { $_.Trim() } | Where-Object { $_ }; Send-MailMessage -SmtpServer '{SMTP服务器}' -Port {SMTP端口} -UseSsl -Credential (New-Object System.Management.Automation.PSCredential('{发件邮箱}', (ConvertTo-SecureString '{SMTP授权码}' -AsPlainText -Force))) -From '{发件邮箱}' -To $to -Subject '{邮件主题}' -Body $msg -Encoding UTF8 }"
+                            ],
+                            "detach": true
+                        }
+                    }
+                }
+            }
+        },
         "跳过分辨率警告": {
             "label": "是否跳过分辨率警报",
             "description": "打开后将跳过分辨率不符的警告提示",
@@ -2774,3 +2908,4 @@
     },
     "version": "v3.0.18"
 }
+

--- a/assets/resource/base/pipeline/snowbreakmustalive.jsonc
+++ b/assets/resource/base/pipeline/snowbreakmustalive.jsonc
@@ -1,0 +1,196 @@
+{
+    "$__mpe_config_新建Pipeline3": {
+        "$__mpe_code": {
+            "prefix": "",
+            "savedViewport": {
+                "x": 740,
+                "y": 94,
+                "zoom": 0.66
+            },
+            "filename": "新建Pipeline3",
+            "version": "v1.4.1",
+        },
+    },
+    "通知失败": {
+        "pre_delay": 0,
+        "action": "DoNothing",
+        "focus": {
+            "Node.Action.Succeeded": {
+                "content": "检测到启动异常或通知流程失败，请尽快检查游戏状态。",
+                "display": [
+                    "log",
+                    "toast",
+                    "notification",
+                    "modal"
+                ]
+            }
+        },
+        "post_delay": 0,
+        "$__mpe_code": {
+            "position": {
+                "x": 995,
+                "y": 263
+            }
+        },
+    },
+    "其他通知": {
+        "action": "DoNothing",
+        "focus": {
+            "Node.Action.Succeeded": {
+                "content": "开服检测通知",
+                "display": [
+                    "log",
+                    "toast",
+                    "notification",
+                    "dialog"
+                ]
+            }
+        },
+        "on_error": [
+            "通知失败"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 657,
+                "y": 455
+            }
+        },
+    },
+    "未开始": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    180,
+                    610,
+                    200,
+                    120
+                ],
+                "expected": [
+                    "开始游戏"
+                ]
+            }
+        },
+        "action": {
+            "type": "Click",
+            "param": {
+                "target": [
+                    180,
+                    610,
+                    200,
+                    120
+                ]
+            }
+        },
+        "next": [
+            "万一呢",
+            "检查主界面_任务_副本",
+            "[JumpBack]尝试服务器"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 12,
+                "y": 184
+            }
+        },
+    },
+    "尝试服务器": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "expected": [
+                    "确定"
+                ]
+            },
+        },
+        "action": {
+            "type": "Click",
+            "param": {}
+        },
+        "post_wait_freezes": 20000,
+        "$__mpe_code": {
+            "position": {
+                "x": 332,
+                "y": 12
+            }
+        },
+    },
+    "万一呢": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    900,
+                    200,
+                    300,
+                    220
+                ],
+                "expected": [
+                    "战斗",
+                    "公告"
+                ]
+            }
+        },
+        "post_delay": 20000,
+        "next": [
+            "通知",
+            "其他通知"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 332,
+                "y": 263
+            }
+        },
+    },
+    "检查主界面_任务_副本": {
+        "recognition": {
+            "type": "OCR",
+            "param": {
+                "roi": [
+                    950,
+                    260,
+                    180,
+                    130
+                ],
+                "expected": "^战斗$",
+                "replace": [],
+            },
+        },
+        "post_delay": 1000,
+        "next": [
+            "通知",
+            "其他通知"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 332,
+                "y": 539
+            }
+        },
+    },
+    "通知": {
+        "action": "DoNothing",
+        "focus": {
+            "Node.Action.Succeeded": {
+                "content": "开服检测通知",
+                "display": [
+                    "log",
+                    "toast",
+                    "notification",
+                    "dialog"
+                ]
+            }
+        },
+        "on_error": [
+            "通知失败"
+        ],
+        "$__mpe_code": {
+            "position": {
+                "x": 652,
+                "y": 307
+            }
+        },
+    },
+}
+


### PR DESCRIPTION
## 变更内容\n- 开服检测通知节点改为 ocus + Command，不再依赖 Notice.py\n- 保留 MAA 消息通道（dialog/modal）\n- Command 在主控侧触发 PowerShell 弹窗/闹钟/邮件\n- 调整检测流程：\n  - 关闭开服检测中的分辨率检查\n  - 移除确认按钮 ROI\n  - 取消全屏 OCR，改为局部 ROI\n\n## 影响文件\n- assets/interface.json\n- assets/resource/base/pipeline/snowbreakmustalive.jsonc\n